### PR TITLE
Fix CSS variable typo in custom.css

### DIFF
--- a/book/custom.css
+++ b/book/custom.css
@@ -44,7 +44,7 @@ table tbody tr:nth-child(2n) {
 
     --sidebar-bg: #383539;
     --sidebar-fg: #fecdb2;
-    --sidebar-non-existant: #feceb454;
+    --sidebar-non-existent: #feceb454;
     --sidebar-active: #ffa07a;
     --scrollbar: var(--sidebar-fg);
 


### PR DESCRIPTION
Fixes a typo in the variable name from `--sidebar-non-existant` to `--sidebar-non-existent`.
